### PR TITLE
Making way for batch operations.

### DIFF
--- a/lib/seraph.js
+++ b/lib/seraph.js
@@ -36,38 +36,56 @@ var seraph = {
   },
 
   /**
-   * Function to create a HTTP request to the rest service. Path is relative to
-   * the service endpoint - `node` gets transformed to
-   * `<options.endpoint>/data/db/node`.
-   * 
-   * If `method` is not supplied, it will default GET, unless `data` is
-   * supplied, in which case it will default to 'POST'.
+   * Create an operation that can later be passed to call().
    *
-   * seraph#call(opts, path, [method='get'], [data], callback);
+   * Path is relative to the service endpoint - `node` gets
+   * transformed to `<options.endpoint>/data/db/node`.
+   * 
+   * If `method` is not supplied, it will default GET, unless `data`
+   * is supplied, in which case it will default to 'POST'.
+   *
+   * seraph#operation(opts, path, [method='get'], [data]);
    */
-  call: function(options, path, method, data, callback) {
+  operation: function(options, path, method, data) {
     // Get args in the right order
-    if (['undefined', 'function'].indexOf(typeof data) !== -1) {
-      callback = data;
-      if (typeof method === 'string') {
-        data = null;
-      }
-    } 
-    if (['object', 'undefined', 'function'].indexOf(typeof method) !== -1) {
-      if (typeof method === 'function') {
-        callback = method;
-        method = undefined;
-      } 
-      
-      if (typeof method === 'object') {
-        data = method;
-        method = 'POST';
-      } else {
-        data = null;
-        method = 'GET';
-      }
+    if (typeof data === 'undefined') {
+      data = null;
     }
-    
+    if (typeof method === 'object') {
+      data = method;
+      method = 'POST';
+    }
+    if (typeof method === 'undefined') {
+      method = 'GET';
+    }
+
+    // Ensure we have a usable HTTP verb.
+    if (typeof method !== 'string') {
+      throw new Error('Invalid HTTP Verb - ' + method);
+    } else {
+      method = method.toUpperCase();
+    }
+
+    return {
+      'method': method,
+      'to'    : path,
+      'body'  : data
+    }
+  },
+
+  /**
+   * Function to call an HTTP request to the rest service.
+   * 
+   * Requires an operation object of form:
+   *   { method: 'PUT'|'POST'|'GET'|'DELETE'
+   *   , to    : path,
+   *   , body  : object }
+   *
+   * Operation objects are easily created by seraph#operation.
+   *
+   * seraph#call(opts, operation, callback);
+   */
+  call: function(options, operation, callback) {
     // Ensure callback is callable. Throw instead of calling back if none.
     if (typeof callback !== 'function') {
       callback = function(err) {
@@ -75,20 +93,13 @@ var seraph = {
       }
     }
 
-    // Ensure we have a usable HTTP verb.
-    if (typeof method !== 'string') { 
-      callback(new Error('Invalid HTTP Verb - ' + method));
-    } else {
-      method = method.toUpperCase();
-    }
-
     var requestOpts = {
-      uri: options.endpoint + '/db/data/' + path,
-      method: method,
+      uri: options.endpoint + '/db/data/' + operation.to,
+      method: operation.method,
       headers: { 'Accept': 'application/json' }
     };
 
-    if (data) requestOpts.json = data;
+    if (operation.body) requestOpts.json = operation.body;
     callback = _.bind(callback, this);
     
     // Allows mocking
@@ -172,7 +183,8 @@ var seraph = {
    * Create a new object. Maps to /node.
    */
   _create: function(options, obj, callback) {
-    this.call(options, 'node', obj, function(err, body, response) {
+    var op = this.operation(options, 'node', obj);
+    this.call(options, op, function(err, body, response) {
       if (err) {
         return callback(err);
       }
@@ -195,7 +207,8 @@ var seraph = {
 
     obj = _.extend({}, obj);
     var endpoint = util.format('node/%d/properties', id);
-    this.call(options, endpoint, 'PUT', obj, function(err, body, response) {
+    var op = this.operation(options, endpoint, 'PUT', obj);
+    this.call(options, op, function(err, body, response) {
       if (err) {
         return callback(err);
       } else {
@@ -218,7 +231,8 @@ var seraph = {
     }
 
     var endpoint = util.format('node/%d/properties', id);
-    this.call(options, endpoint, function(err, body) {
+    var op = this.operation(options, endpoint);
+    this.call(options, op, function(err, body) {
       if (err) {
         return callback(err);
       } else {
@@ -243,7 +257,8 @@ var seraph = {
     }
 
     var endpoint = util.format('node/%d', id);
-    this.call(options, endpoint, 'DELETE', function(err) {
+    var op = this.operation(options, endpoint, 'DELETE');
+    this.call(options, op, function(err) {
       callback(err);
     });
   },
@@ -288,7 +303,8 @@ var seraph = {
     }
 
     var endpoint = util.format('relationship/%d', id);
-    this.call(options, endpoint, function(err, linkData) {
+    var op = this.operation(options, endpoint);
+    this.call(options, op, function(err, linkData) {
       if (err) {
         callback(err);
       } else {
@@ -333,7 +349,8 @@ var seraph = {
     }
 
     var endpoint = util.format('node/%d/relationships', firstId);
-    this.call(options, endpoint, 'POST', request, function(err, linkData) {
+    var op = this.operation(options, endpoint, 'POST', request);
+    this.call(options, op, function(err, linkData) {
       if (err) {
         callback(err);
       } else {
@@ -357,7 +374,8 @@ var seraph = {
     }
 
     query = { query: query, params: params };
-    this.call(options, 'cypher', query, function(err, result) {
+    var op = this.operation(options, 'cypher', query);
+    this.call(options, op, function(err, result) {
       if (err) {
         callback(err);
       } else {

--- a/test/seraph.js
+++ b/test/seraph.js
@@ -1,3 +1,5 @@
+/* -*- Mode: Javascript; js-indent-level: 2 -*- */
+
 /**
  * Goal: Seraph 1.0
  * 
@@ -58,7 +60,8 @@ describe('seraph#call', function() {
       assert.equal(opts.method, 'GET');
       done();
     });
-    seraph.call(opts, '');
+    var op = seraph.operation(opts, '');
+    seraph.call(opts, op);
   });
 
   it('should infer POST request if data supplied', function(done) {
@@ -73,7 +76,8 @@ describe('seraph#call', function() {
       assert.deepEqual(opts.json, testObject);
       done();
     });
-    seraph.call(opts, '', testObject);
+    var op = seraph.operation(opts, '', testObject);
+    seraph.call(opts, op);
   });
 
   it('should add /db/data/ to url', function(done) {
@@ -83,7 +87,8 @@ describe('seraph#call', function() {
       assert.equal(opts.uri, '/db/data/');
       done();
     });
-    seraph.call(opts, '', obj);
+    var op = seraph.operation(opts, '', obj);
+    seraph.call(opts, op);
   });
 });
 
@@ -215,7 +220,7 @@ describe('seraph#delete', function() {
 
     function del(user, done) {
       db.delete(user, function(err) {
-        assert.ok(!err);
+         assert.ok(!err);
         db.read(user, function(err) {
           assert.ok(!!err);
           done();


### PR DESCRIPTION
Some minor corrections, and split up call() into two steps: operation() to create the operation, and call() to execute the operation at the REST API.

Intended way forward is to create a function callBatch() which takes an array of operations and calls the batch endpoint with them.

[edited for englishing some the words]
