### PR TITLE
Dep extended to node 0.8.  Fixed mocha dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "underscore": "~1.3.3"
   },
   "devDependencies": {
-    "mocha": "~1.1.0"
+    "mocha": "~1.2.0"
   }
 }


### PR DESCRIPTION
In a fit of WTF, the Mocha people have decided to unpublish mocha@1.1.x.  They are wrong and evil for doing so, and we should think less of them for it.

Aanyway tests work with Mocha 1.2.x, so upped to that.
