### PR TITLE
Catches fire on queries with optional relationships.

### DIFF
--- a/lib/seraph.js
+++ b/lib/seraph.js
@@ -199,10 +199,13 @@ Seraph.nodeFlags = [
   'self'
 ];
 Seraph.prototype._isNode = function(node) {
+  if (!node || typeof node !== 'object') {
+    return false;
+  }
+
   var inNode = node.hasOwnProperty.bind(node);
-  return  typeof node === 'object' && 
-          Seraph.nodeFlags.every(inNode) && 
-          typeof node.data === 'object';
+  return Seraph.nodeFlags.every(inNode) && 
+         typeof node.data === 'object';
 };
 
 /**
@@ -216,10 +219,13 @@ Seraph.relationshipFlags = [
   'end'
 ];
 Seraph.prototype._isRelationship = function(rel) {
+  if (!rel || typeof rel !== 'object') {
+    return false;
+  }
+
   var inRelationship = rel.hasOwnProperty.bind(rel);
-  return  typeof rel === 'object' &&
-          Seraph.relationshipFlags.every(inRelationship) &&
-          typeof rel.data === 'object';
+  return Seraph.relationshipFlags.every(inRelationship) &&
+         typeof rel.data === 'object';
 };
 
 /**

--- a/test/seraph.js
+++ b/test/seraph.js
@@ -709,7 +709,7 @@ describe('seraph#query, seraph#queryRaw', function() {
       cypher    += "return x, n ";
       db.query(cypher, function(err, result) {
         assert.ok(!err);
-        assert.deepEqual([ user ], result);
+        assert.deepEqual([{x: user, n: null}], result);
         done();
       });
     }


### PR DESCRIPTION
Given graph containing only one naked node: `{id:0}`, run the following query:

```
start x=node(0) match x->[?:FEARS]->y return y
```

This will cause an uncaught exception:

```
/dat/path/seraph/lib/seraph.js:197
  var inNode = node.hasOwnProperty.bind(node);
```
