### PR TITLE
Attempted fix for #68 - don't return strings as errors

### DIFF
--- a/lib/seraph.js
+++ b/lib/seraph.js
@@ -148,7 +148,18 @@ Seraph.prototype.call = function(operation, callback) {
     if (err) {
       callback(err);
     } else if (response.statusCode < 200 || response.statusCode >= 300) {
-      callback(body || response.statusCode);
+      // Pass on neo4j error
+      var error;
+      if (body instanceof Object && body.exception) {
+        error = new Error(body.message);
+        error.neo4jException = body.exception;
+        error.neo4jStacktrace = body.stacktrace;
+      } else {
+        // Can't understand this as a neo4j error
+        error = new Error(body || response.statusCode);
+      }
+      error.statusCode = response.statusCode;
+      callback(error);
     } else {
       if (typeof body === 'string') {
         try {

--- a/test/seraph.js
+++ b/test/seraph.js
@@ -83,6 +83,23 @@ var stopDb = function(done) {
 before(refreshDb);
 after(stopDb);
 
+describe('errors', function() {
+  it('should give Error objects with message', function(done) {
+    db.read(console, function(err, data) {
+      assert.ok(err instanceof Error);
+      assert.ok(err.message);
+      done();
+    });
+  });
+
+  it('should decorate errors originating from neo4j', function(done) {
+    db.query("herp derp;", function(err, data) {
+      assert.ok(err.neo4jException);
+      done();
+    });
+  });
+});
+
 describe('seraph#call, seraph#operation', function() {
   var seraph = _seraph(testDatabase);
   function setupMock(mock) {


### PR DESCRIPTION
Also paves the way for differentiating accurately between neo4j errors and seraph/submodule errors.
