### PR TITLE
Fix issue #21: Can specify endpoint other than /db/data

### DIFF
--- a/lib/seraph.js
+++ b/lib/seraph.js
@@ -8,7 +8,10 @@ var util = require('util');
 
 var defaultOptions = {
     // Location of the server
-    endpoint: 'http://localhost:7474'
+    server: 'http://localhost:7474'
+
+    // datbase endpoint
+  , endpoint: '/db/data'
 
     // The key to use when inserting an id into objects. 
   , id: 'id'
@@ -24,9 +27,14 @@ var bindAllTo = function(context, all) {
 
 function Seraph(options) {
   if (typeof options === 'string') {
-    options = { endpoint: options };
+    options = { server: options };
   };
   this.options = _.extend({}, defaultOptions, options);
+  this.options.server = this.options.server
+    .replace(/\/$/, '');        // remove trailing /
+  this.options.endpoint = this.options.endpoint
+    .replace(/\/$/, '')         // remove trailing /
+    .replace(/^([^/])/, '/$1'); // add leading /
 
   _.bindAll(this);
 
@@ -47,7 +55,7 @@ function Seraph(options) {
  * Create an operation that can later be passed to call().
  *
  * Path is relative to the service endpoint - `node` gets
- * transformed to `<options.endpoint>/data/db/node`.
+ * transformed to `<options.server><options.endpoint>/node`.
  * 
  * If `method` is not supplied, it will default GET, unless `data`
  * is supplied, in which case it will default to 'POST'.
@@ -135,7 +143,7 @@ Seraph.prototype.call = function(operation, callback) {
   }
 
   var requestOpts = {
-    uri: this.options.endpoint + '/db/data/' + operation.to,
+    uri: this.options.server + this.options.endpoint + '/' + operation.to,
     method: operation.method,
     headers: { 'Accept': 'application/json' }
   };
@@ -260,7 +268,8 @@ Seraph.prototype._isRelationship = function(rel) {
  * Returns the url to an entity given an id
  */
 Seraph.prototype._location = function(type, id) {
-  return util.format('%s/data/db/%s/%d', this.options.endpoint, type, id);
+  return util.format('%s%s/%s/%d',
+                     this.options.server, this.options.endpoint, type, id);
 };
 
 /**


### PR DESCRIPTION
This renames the existing configuration parameter "endpoint" to "server", but that shouldn't cause problems as that was undocumented anyway.
