### PR TITLE
find signature listed start property

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ db.save({ name: 'Jon' }, function(err, node) {
 ---------------------------------------
 
 <a name="node.find" />
-### find(predicate, [any, [start, [label,]] callback)
+### find(predicate, [any, [label,] callback)
 *Aliases: __node.find__*
 
 Perform a query based on a predicate. The predicate is translated to a


### PR DESCRIPTION
It looks like that does not exist. Also, it seems the example is wrong, it should be

``` javascript
var predicate = { australian: true };
var people = db.find(predicate, function (err, objs) {
    if (err) throw err;
    assert.equals(3, objs.length);
};
```
