### PR TITLE
Update seraph.js

### DIFF
--- a/lib/seraph.js
+++ b/lib/seraph.js
@@ -324,7 +324,7 @@ Seraph.prototype._createRelationshipObject = function(relationshipData) {
  */
 Seraph.prototype._createNodeObject = function(nodeData) {
   var nodeObj = nodeData.data || {};
-  nodeObj[this.options.id] = this._extractId(nodeData.self);
+  if(!nodeObj[this.options.id]) nodeObj[this.options.id] = this._extractId(nodeData.self);
 
   return nodeObj;
 };


### PR DESCRIPTION
Update of _createNodeObject to address overwriting of ['id'] property of the object. Currently if the object in the database has property named ID that is not the internal ID assigned to the node, the function overwrites it with internal ID. This quick fix checks to see if ID already exists, if it doesn't it allows the internal ID to be used.