### PR TITLE
Fixed BatchSeraph null or undefined options bug, update README for new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ __Arguments__
   * `user` (default = `"neo4j"`): the username to authenticate with.
   * `pass` (default = `"neo4j"`): the password to authenticate with.
   * `id` (default = `"id"`): the name of the attribute seraph will add to new nodes when they are created and that it will use to find nodes when performing updates with `node.save` and the like.
-* `server` (string) - Short form to specify server parameter only. `"http://localhorse:4747"` is equivalent to `{ server: "http://localhorse:4747" }`.
+  * `agent` (default = null): the http agent for requests to neo4j server. The same can be used for keep-alive connections to server. Can use [agentkeepalive](https://github.com/node-modules/agentkeepalive "agentkeepalive") module to create a keep-alive agent. It's a recommended option for high performance and low latency client.
+  * `xstream` (default = false): if true, passes new X-Stream option to neo4j server. It's a recommended option for high performance and low latency client.
+* `server` (string) - Short form to specify server parameter only. `"http://localhost:4747"` is equivalent to `{ server: "http://localhost:4747" }`.
 
 **Note** that as of Neo4j 2.2.0, user authentication is required. You will not
 be able to access resources before supplying a username or password that is not

--- a/lib/seraph.js
+++ b/lib/seraph.js
@@ -324,7 +324,8 @@ function BatchSeraph(parentSeraph) {
   function wrapFunctions(parent, target) {
     var derived = target || {};
 
-    Object.keys(parent).forEach(function(key) {
+    // parent could be undefined or null, so skip walking such
+    parent && Object.keys(parent).forEach(function(key) {
       var valueType = typeof parent[key];
 
       if (valueType === 'function') {

--- a/lib/seraph.js
+++ b/lib/seraph.js
@@ -326,6 +326,8 @@ function BatchSeraph(parentSeraph) {
 
     // parent could be undefined or null, so skip walking such
     parent && Object.keys(parent).forEach(function(key) {
+      if (key == 'agent') return;
+
       var valueType = typeof parent[key];
 
       if (valueType === 'function') {


### PR DESCRIPTION
1) With new agent option, some of the values can be null or undefined. So fixed BatchSeraph method to avoid walking down such keys.
2) Skip walking down agent key -- agentkeepalive object is too deep and circular (better way than that check ?)
3) Updated README for new agent and xstream option.