### PR TITLE
Neo4J 3 - db.find() - cypher requires parentheses in patterns

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -305,7 +305,7 @@ var node = module.exports = {
     }, []);
 
     var cypher = [ 
-      label == null ? "MATCH n" : util.format("MATCH (n:`%s`)", label),
+      label == null ? "MATCH (n)" : util.format("MATCH (n:`%s`)", label),
       matchers.length > 0 ? "WHERE" : "",
       matchers.join(any ? " or " : " and "), 
       "RETURN n"


### PR DESCRIPTION
Cypher always preferred parentheses when matching nodes and patterns.  In Neo4J 3.0, it is required.  Error returned from neo4j 3.

db.find()

`Neo.ClientError.Statement.SyntaxError`
`Parentheses are required to identify nodes in patterns, i.e. (n) (line 1, column 7 (offset: 6))\\n\"MATCH n WHERE n.key = {key} RETURN n\"\\n       ^`