### PR TITLE
fix null parameters converted to empty objects

### DIFF
--- a/lib/bolt/seraph.js
+++ b/lib/bolt/seraph.js
@@ -243,7 +243,7 @@ class Seraph {
       else if (obj instanceof Promise) return obj.then(val => treatObj(val));
       else if (neo4j.isInt(obj)) return pr(obj);
       else if (Array.isArray(obj)) return Promise.all(obj.map(treatObj));
-      else if (typeof obj == 'object') 
+      else if (typeof obj == 'object' && obj !== null) 
         return Promise.all(_.map(obj, (v,k) => { return treatObj(v).then(v => [k,v]) }))
           .then(tuples => _.object(tuples))
       else return pr(obj);


### PR DESCRIPTION
`null` parameters get converted to empy objects (`{}`) which causes Neo4j to throw errors